### PR TITLE
Update the source URL of dictionary

### DIFF
--- a/dictionary/ipadic.properties
+++ b/dictionary/ipadic.properties
@@ -1,4 +1,4 @@
-dic.home=http://sourceforge.jp/frs/redir.php?m=jaist&f=/ipadic/24432
+dic.home=http://chasen.naist.jp/stable/ipadic/
 dic.version=2.6.1
 dic.archive=ipadic-${dic.version}.tar.gz
 dic.dir=ipadic-${dic.version}


### PR DESCRIPTION
Address the issue failed to download a dictionary file due to redirection from https to http, which is unsafe and not allowed. Thus, change the source URL to [NAIST repository](http://chasen.naist.jp/stable/ipadic/).