### PR TITLE
#31 Support Solr/Lucene 8.0.0

### DIFF
--- a/dictionary/ipadic.properties
+++ b/dictionary/ipadic.properties
@@ -1,4 +1,4 @@
-dic.home=http://chasen.naist.jp/stable/ipadic/
+dic.home=http://jaist.dl.osdn.jp/ipadic/24432/
 dic.version=2.6.1
 dic.archive=ipadic-${dic.version}.tar.gz
 dic.dir=ipadic-${dic.version}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,10 @@ compileJava.options.encoding = UTF-8
 # set default dictionary type
 # to change the dictionary type to naist-chasen, gradle
 dictype = ipadic
-luceneVersion = 7.4.0
-junitVersion = 4.10
-randomizedrunnerVersion = 2.6.0
-icu4jVersion = 61.1
+luceneVersion = 8.0.0
+junitVersion = 4.12
+randomizedrunnerVersion = 2.7.2
+icu4jVersion = 62.1
 restletVersion = 2.3.0
 
 # directories

--- a/src/main/java/net/java/sen/util/IOUtils.java
+++ b/src/main/java/net/java/sen/util/IOUtils.java
@@ -38,14 +38,14 @@ public class IOUtils {
   }
 
   /**
-   * Closes all given <tt>Closeable</tt>s.  Some of the
-   * <tt>Closeable</tt>s may be null; they are
+   * Closes all given <code>Closeable</code>s.  Some of the
+   * <code>Closeable</code>s may be null; they are
    * ignored.  After everything is closed, the method either
    * throws the first exception it hit while closing, or
    * completes normally if there were no exceptions.
-   * 
+   *
    * @param objects
-   *          objects to call <tt>close()</tt> on
+   *          objects to call <code>close()</code> on
    */
   public static void close(Closeable... objects) throws IOException {
     Throwable th = null;
@@ -71,11 +71,11 @@ public class IOUtils {
     }
   }
   /**
-   * Closes all given <tt>Closeable</tt>s, suppressing all thrown exceptions.
-   * Some of the <tt>Closeable</tt>s may be null, they are ignored.
-   * 
+   * Closes all given <code>Closeable</code>s, suppressing all thrown exceptions.
+   * Some of the <code>Closeable</code>s may be null, they are ignored.
+   *
    * @param objects
-   *          objects to call <tt>close()</tt> on
+   *          objects to call <code>close()</code> on
    */
   public static void closeWhileHandlingException(Closeable... objects) throws IOException {
     for (Closeable object : objects) {
@@ -100,5 +100,5 @@ public class IOUtils {
       }
     }
   }
-  
+
 }


### PR DESCRIPTION
- Fix an issue that is not able to download IPA dictionary archive file to build a system dictionary.
- Fix an issue that is not able to generate Javadoc properly.
- Update dependencies to support Solr/Lucene 8.0.0.