### PR TITLE
Adding/Updating DictionaryTrainer to properly assign the connection cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,37 @@ $ ./gradlew :dictionary:preprocessUnidic -PuseModel=true
 $ ./gradlew jarWithUnidic
 ```
 
+To add custom words to the dictionary with CRF-computed costs, prepare a CSV file
+with at least 13 columns per line:
+
+```
+surface,leftId,rightId,cost,pos1,pos2,pos3,pos4,cType,cForm,orthBase,pron,pronBase
+```
+
+For example:
+
+```
+バラク,0,0,0,名詞,固有名詞,人名,名,*,*,バラク,バラク,バラク
+オバマ,0,0,0,名詞,固有名詞,人名,姓,*,*,オバマ,オバマ,オバマ
+```
+
+The `leftId`, `rightId`, and `cost` columns (0,0,0) are placeholders — when
+`-PuseModel=true` is specified, the word cost is recomputed from the CRF model
+based on the POS features. Connection costs are resolved at runtime through
+POS key matching against the existing UniDic connection cost matrix.
+
+```
+$ ./gradlew :dictionary:preprocessUnidic -PuseModel=true -PcustomDic=/path/to/custom.csv
+$ ./gradlew jarWithUnidic
+```
+
+Multiple custom dictionary files can be specified (space-separated):
+
+```
+$ ./gradlew :dictionary:preprocessUnidic -PuseModel=true \
+    -PcustomDic="/path/to/names.csv /path/to/places.csv"
+```
+
 Please note that you should modify the following line in `gradle.properties` if you want to target a different Lucene version.
 
 ```

--- a/dictionary/build.gradle
+++ b/dictionary/build.gradle
@@ -242,11 +242,20 @@ task preprocessUnidic(dependsOn: [unpackUnidic, rootProject.tasks.compileJava]) 
         // Pass --use-model if the project property is set:
         //   ./gradlew preprocessUnidic -PuseModel=true
         // Optionally override cost-factor with -PcostFactor=<n>
+        // Optionally merge custom dictionary entries with -PcustomDic=<path>
+        //   (space-separated for multiple files)
         if (project.hasProperty('useModel') && project.property('useModel').toString().equalsIgnoreCase('true')) {
             javaArgs += ['--use-model']
         }
         if (project.hasProperty('costFactor')) {
             javaArgs += ['--cost-factor', project.property('costFactor').toString()]
+        }
+        if (project.hasProperty('customDic')) {
+            project.property('customDic').toString().split(/\s+/).each { path ->
+                if (!path.isEmpty()) {
+                    javaArgs += ['--custom-dic', path]
+                }
+            }
         }
 
         execHelper.execOperations.javaexec {

--- a/src/main/java/net/java/sen/compiler/UnidicPreprocessor.java
+++ b/src/main/java/net/java/sen/compiler/UnidicPreprocessor.java
@@ -26,9 +26,12 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +124,18 @@ public class UnidicPreprocessor {
   static final String EOS_POS_KEY     = "文末,*,*,*,*,*,*";
   static final String UNKNOWN_POS_KEY = "名詞,サ変接続,*,*,*,*,*";
 
+  // Custom dictionary column indices (same layout as lex.csv columns 0-12)
+  private static final int CUSTOM_SURFACE   = 0;
+  private static final int CUSTOM_LEFT_ID   = 1;  // placeholder (ignored)
+  private static final int CUSTOM_RIGHT_ID  = 2;  // placeholder (ignored)
+  private static final int CUSTOM_WORD_COST = 3;  // placeholder when using model
+  private static final int CUSTOM_POS1      = 4;  // F[0]
+  private static final int CUSTOM_CFORM     = 9;  // F[5]
+  private static final int CUSTOM_ORTH_BASE = 10;
+  private static final int CUSTOM_PRON      = 11;
+  private static final int CUSTOM_PRON_BASE = 12;
+  private static final int CUSTOM_MIN_COLS  = 13;
+
   private final File dictDir;
 
   /**
@@ -130,13 +145,40 @@ public class UnidicPreprocessor {
   private final CostCalculator costCalculator;
 
   /**
+   * Optional custom dictionary files whose entries are appended to
+   * {@code dictionary.csv} with costs computed by the CRF model.
+   */
+  private final List<File> customDicFiles;
+
+  /**
    * @param dictDir        path to the unidic-cwj-202512_full directory
    * @param costCalculator use CRF weights for costs; pass {@code null} to use
    *                       the raw costs from lex.csv and matrix.def
    */
   public UnidicPreprocessor(File dictDir, CostCalculator costCalculator) {
+    this(dictDir, costCalculator, null);
+  }
+
+  /**
+   * @param dictDir        path to the unidic-cwj-202512_full directory
+   * @param costCalculator use CRF weights for costs; pass {@code null} to use
+   *                       the raw costs from lex.csv and matrix.def
+   * @param customDicFiles optional list of custom dictionary CSV files whose
+   *                       entries are appended to {@code dictionary.csv}.
+   *                       Each line must have at least 13 columns:
+   *                       surface,leftId,rightId,cost,pos1,pos2,pos3,pos4,
+   *                       cType,cForm,orthBase,pron,pronBase.
+   *                       When {@code costCalculator} is non-null, word costs
+   *                       are recomputed from CRF weights; otherwise the raw
+   *                       cost value (column 3) is used.
+   */
+  public UnidicPreprocessor(File dictDir, CostCalculator costCalculator,
+                            List<File> customDicFiles) {
     this.dictDir        = dictDir;
     this.costCalculator = costCalculator;
+    this.customDicFiles = customDicFiles != null
+        ? Collections.unmodifiableList(new ArrayList<>(customDicFiles))
+        : Collections.emptyList();
   }
 
   // --------------------------------------------------------------------------
@@ -251,7 +293,75 @@ public class UnidicPreprocessor {
         writer.write('\n');
         count++;
       }
-      System.out.println("  " + count + " word entries written");
+      System.out.println("  " + count + " word entries from lex.csv");
+
+      // Append custom dictionary entries
+      long customCount = 0;
+      for (File customFile : customDicFiles) {
+        System.out.println("  Processing custom dictionary: " + customFile.getName());
+        try (FileInputStream cfis = new FileInputStream(customFile);
+             CSVParser customParser = new CSVParser(cfis, "UTF-8")) {
+          String[] crow;
+          while ((crow = customParser.nextTokens()) != null) {
+            if (crow.length < CUSTOM_MIN_COLS) continue;
+
+            String surface  = crow[CUSTOM_SURFACE];
+            String pos1     = crow[CUSTOM_POS1];
+            String pos2     = crow[CUSTOM_POS1 + 1];
+            String pos3     = crow[CUSTOM_POS1 + 2];
+            String pos4     = crow[CUSTOM_POS1 + 3];
+            String cType    = crow[CUSTOM_POS1 + 4];
+            String cForm    = crow[CUSTOM_CFORM];
+            String orthBase = crow[CUSTOM_ORTH_BASE];
+            String pron     = crow[CUSTOM_PRON];
+            String pronBase = crow[CUSTOM_PRON_BASE];
+
+            // Build F[] array: F[0]-F[5] from custom entry, F[6]-F[15] = "*"
+            String[] f = new String[F_COUNT];
+            for (int j = 0; j < F_COUNT; j++) {
+              int col = CUSTOM_POS1 + j;
+              f[j] = (col < crow.length) ? crow[col] : "*";
+            }
+
+            // Compute word cost (CRF or raw)
+            int wordCost;
+            if (costCalculator != null) {
+              wordCost = costCalculator.computeWordCost(f, charType(surface));
+            } else {
+              wordCost = parseInt(crow[CUSTOM_WORD_COST]);
+            }
+
+            // Write row (same format as lex.csv entries)
+            writer.write(enquote(surface));
+            writer.write(',');
+            writer.write(Integer.toString(wordCost));
+            writer.write(',');
+            writer.write(escapeField(pos1));
+            writer.write(',');
+            writer.write(escapeField(pos2));
+            writer.write(',');
+            writer.write(escapeField(pos3));
+            writer.write(',');
+            writer.write(escapeField(pos4));
+            writer.write(',');
+            writer.write(escapeField(cType));
+            writer.write(',');
+            writer.write(escapeField(cForm));
+            writer.write(',');
+            writer.write(enquote(orthBase));
+            writer.write(',');
+            writer.write(enquote(pron));
+            writer.write(',');
+            writer.write(enquote(pronBase));
+            writer.write('\n');
+            customCount++;
+          }
+        }
+      }
+      if (customCount > 0) {
+        System.out.println("  " + customCount + " custom word entries appended");
+      }
+      System.out.println("  " + (count + customCount) + " total word entries written");
     }
   }
 

--- a/src/main/java/net/java/sen/tools/DictionaryTrainer.java
+++ b/src/main/java/net/java/sen/tools/DictionaryTrainer.java
@@ -22,6 +22,8 @@ import net.java.sen.trainer.ModelWeightIndex;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * CLI entry point for preprocessing a UniDic dictionary into the intermediate
@@ -44,6 +46,12 @@ import java.io.IOException;
  *   --feature-def &lt;path&gt;  Path to feature.def. Default: &lt;dict-dir&gt;/feature.def
  *   --cost-factor &lt;n&gt;     Integer multiplier for float→int cost conversion.
  *                          Default: 700 (from UniDic dicrc)
+ *   --custom-dic  &lt;path&gt;  Path to a custom dictionary CSV file. May be
+ *                          specified multiple times. Each line must have at
+ *                          least 13 columns: surface,leftId,rightId,cost,
+ *                          pos1,pos2,pos3,pos4,cType,cForm,orthBase,pron,
+ *                          pronBase. When --use-model is active, word costs
+ *                          are recomputed from CRF weights.
  * </pre>
  *
  * <h2>Two-phase pipeline</h2>
@@ -70,6 +78,7 @@ public class DictionaryTrainer {
     File    featureFile = null;
     boolean useModel    = false;
     int     costFactor  = 700;
+    List<File> customDicFiles = new ArrayList<>();
 
     for (int i = 0; i < args.length; i++) {
       String arg = args[i];
@@ -85,6 +94,12 @@ public class DictionaryTrainer {
         useModel = true;
       } else if ("--cost-factor".equals(arg)) {
         costFactor = Integer.parseInt(args[++i]);
+      } else if ("--custom-dic".equals(arg)) {
+        File customFile = new File(args[++i]);
+        if (!customFile.isFile()) {
+          throw new IllegalArgumentException("Custom dictionary not found: " + customFile);
+        }
+        customDicFiles.add(customFile);
       } else {
         printUsage();
         throw new IllegalArgumentException("Unknown argument: " + arg);
@@ -134,8 +149,17 @@ public class DictionaryTrainer {
       System.out.println("[DictionaryTrainer] Phase 1 only: using raw costs from lex.csv / matrix.def");
     }
 
+    if (!customDicFiles.isEmpty()) {
+      System.out.println("[DictionaryTrainer] " + customDicFiles.size()
+          + " custom dictionary file(s) will be merged:");
+      for (File f : customDicFiles) {
+        System.out.println("  " + f.getAbsolutePath());
+      }
+    }
+
     // Run preprocessor
-    UnidicPreprocessor preprocessor = new UnidicPreprocessor(dictDir, costCalculator);
+    UnidicPreprocessor preprocessor = new UnidicPreprocessor(
+        dictDir, costCalculator, customDicFiles);
     preprocessor.build(outputDir);
 
     System.out.println("[DictionaryTrainer] Preprocessing complete. "
@@ -149,5 +173,6 @@ public class DictionaryTrainer {
     System.err.println("  --model      <path>     model.def (default: <dict-dir>/model.def)");
     System.err.println("  --feature-def <path>    feature.def (default: <dict-dir>/feature.def)");
     System.err.println("  --cost-factor <n>       float→int scale factor (default: 700)");
+    System.err.println("  --custom-dic  <path>    custom dictionary CSV (may be repeated)");
   }
 }

--- a/src/test/java/net/java/sen/compiler/UnidicPreprocessorTest.java
+++ b/src/test/java/net/java/sen/compiler/UnidicPreprocessorTest.java
@@ -18,11 +18,18 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import net.java.sen.trainer.CostCalculator;
+import net.java.sen.trainer.FeatureExtractor;
+import net.java.sen.trainer.FeatureTemplateParser;
+import net.java.sen.trainer.ModelWeightIndex;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 
@@ -300,5 +307,122 @@ public class UnidicPreprocessorTest {
   private String readFile(File f) throws Exception {
     byte[] bytes = java.nio.file.Files.readAllBytes(f.toPath());
     return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  // -----------------------------------------------------------------------
+  // Custom dictionary integration tests
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testCustomDicEntriesAppendedToDictionaryCsv() throws Exception {
+    File dictDir   = writeFakeDictDir();
+    File outputDir = tmp.newFolder("custom-output");
+
+    // Write a custom dictionary file
+    File customDic = tmp.newFile("custom.csv");
+    writeFile(customDic,
+        "バラク,0,0,0,名詞,固有名詞,人名,名,*,*,バラク,バラク,バラク\n" +
+        "オバマ,0,0,0,名詞,固有名詞,人名,姓,*,*,オバマ,オバマ,オバマ\n");
+
+    UnidicPreprocessor prep = new UnidicPreprocessor(
+        dictDir, null, Collections.singletonList(customDic));
+    prep.build(outputDir);
+
+    String content = readFile(new File(outputDir, "dictionary.csv"));
+    // Original entries still present
+    assertTrue("should contain 東京", content.contains("東京"));
+    assertTrue("should contain 行く", content.contains("行く"));
+    // Custom entries appended
+    assertTrue("should contain バラク", content.contains("バラク"));
+    assertTrue("should contain オバマ", content.contains("オバマ"));
+  }
+
+  @Test
+  public void testCustomDicRawCostUsedWithoutModel() throws Exception {
+    File dictDir   = writeFakeDictDir();
+    File outputDir = tmp.newFolder("custom-raw");
+
+    File customDic = tmp.newFile("custom-raw.csv");
+    writeFile(customDic,
+        "テスト,0,0,5000,名詞,普通名詞,一般,*,*,*,テスト,テスト,テスト\n");
+
+    UnidicPreprocessor prep = new UnidicPreprocessor(
+        dictDir, null, Collections.singletonList(customDic));
+    prep.build(outputDir);
+
+    String content = readFile(new File(outputDir, "dictionary.csv"));
+    // The raw cost 5000 should be used as-is
+    assertTrue("should contain テスト with raw cost",
+        content.contains("テスト,5000,"));
+  }
+
+  @Test
+  public void testCustomDicCostRecomputedWithModel() throws Exception {
+    File dictDir   = writeFakeDictDir();
+    File outputDir = tmp.newFolder("custom-model");
+
+    // Set up a simple CRF model: weight 1.0 for "A:名詞" unigram
+    File featureFile = tmp.newFile("feature.def");
+    writeFile(featureFile, "UNIGRAM A:%F[0]\n");
+
+    File modelFile = tmp.newFile("model.def");
+    writeFile(modelFile, "\n1.0\tA:名詞\n");
+
+    FeatureTemplateParser parser = new FeatureTemplateParser();
+    parser.load(featureFile);
+    ModelWeightIndex model = new ModelWeightIndex();
+    model.load(modelFile);
+    FeatureExtractor extractor = new FeatureExtractor(parser);
+    CostCalculator calc = new CostCalculator(extractor, model, 700);
+
+    File customDic = tmp.newFile("custom-model.csv");
+    // Raw cost is 0, but CRF should compute 700 (1.0 * 700)
+    writeFile(customDic,
+        "バラク,0,0,0,名詞,固有名詞,人名,名,*,*,バラク,バラク,バラク\n");
+
+    UnidicPreprocessor prep = new UnidicPreprocessor(
+        dictDir, calc, Collections.singletonList(customDic));
+    prep.build(outputDir);
+
+    String content = readFile(new File(outputDir, "dictionary.csv"));
+    // CRF-computed cost: round(1.0 * 700) = 700
+    assertTrue("custom entry should have CRF-computed cost 700",
+        content.contains("バラク,700,"));
+  }
+
+  @Test
+  public void testMultipleCustomDicFiles() throws Exception {
+    File dictDir   = writeFakeDictDir();
+    File outputDir = tmp.newFolder("multi-custom");
+
+    File customDic1 = tmp.newFile("custom1.csv");
+    writeFile(customDic1,
+        "バラク,0,0,0,名詞,固有名詞,人名,名,*,*,バラク,バラク,バラク\n");
+
+    File customDic2 = tmp.newFile("custom2.csv");
+    writeFile(customDic2,
+        "オバマ,0,0,0,名詞,固有名詞,人名,姓,*,*,オバマ,オバマ,オバマ\n");
+
+    UnidicPreprocessor prep = new UnidicPreprocessor(
+        dictDir, null, Arrays.asList(customDic1, customDic2));
+    prep.build(outputDir);
+
+    String content = readFile(new File(outputDir, "dictionary.csv"));
+    assertTrue("should contain バラク from first custom dic", content.contains("バラク"));
+    assertTrue("should contain オバマ from second custom dic", content.contains("オバマ"));
+  }
+
+  @Test
+  public void testEmptyCustomDicListProducesSameOutput() throws Exception {
+    File dictDir    = writeFakeDictDir();
+    File outputDir1 = tmp.newFolder("no-custom");
+    File outputDir2 = tmp.newFolder("empty-custom");
+
+    new UnidicPreprocessor(dictDir, null).build(outputDir1);
+    new UnidicPreprocessor(dictDir, null, Collections.<File>emptyList()).build(outputDir2);
+
+    String dict1 = readFile(new File(outputDir1, "dictionary.csv"));
+    String dict2 = readFile(new File(outputDir2, "dictionary.csv"));
+    assertEquals("empty custom list should produce identical output", dict1, dict2);
   }
 }


### PR DESCRIPTION
Update DictionaryTrainer to properly compute connection costs when building the system dictionary from CSV input and existing dictionary data.

Example CSV input
```
バラク,0,0,0,名詞,固有名詞,人名,名,*,*,バラク,バラク,バラク
オバマ,0,0,0,名詞,固有名詞,人名,姓,*,*,オバマ,オバマ,オバマ
```